### PR TITLE
商品検索強化

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,8 +426,8 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.1)
   rails-controller-testing
-  rspec-rails
   ransack
+  rspec-rails
   sass-rails (~> 5.0)
   seed-fu
   selenium-webdriver

--- a/app/assets/stylesheets/search/searches.scss
+++ b/app/assets/stylesheets/search/searches.scss
@@ -1,7 +1,7 @@
 .search{
   width:99vw;
-  min-height:100vh;
   height: 100%;
+  min-height:calc(70vh - 82px);
   &__container{
     &__left{
 

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,7 +1,5 @@
 class SearchesController < ApplicationController
   def index
-    @items_p = Item.all.order(created_at: :desc)
-    @items_p = Item.page(params[:page]).per(10).order('updated_at DESC')
     @items = Item.search(params[:search]).limit(100)
     @search = params[:search]
   end

--- a/app/views/searches/index.html.haml
+++ b/app/views/searches/index.html.haml
@@ -6,7 +6,16 @@
       -# = paginate @items_p #ページネーション機能
     .search__container__right
       %section.itemsBox
-        -if @search.present? #検索結果の有無を確認（真）
+        -if @search.empty? #検索結果の有無を確認（真）
+          %h2.search__result__nil
+            お探しの商品はございません
+        - elsif @items.count == 0
+          %h2.search__result__nil
+            お探しの商品はございません
+        - elsif @search.include?("%") || @search.include?("_")
+          %h2.search__result__nil
+            お探しの商品はございません
+        -else #検索結果の有無を確認（偽）
           %h2.search__result__head
             =@search
             %span.search__result__head__text
@@ -38,11 +47,8 @@
                           .right
                             -# 大ハートボタン
                             %input#204626156.likeBtn{alt: "1", src: "https://image.shoppies.jp/img_m/icon_suki_off.gif", type: "image", value: "0"}/
-
-        -else #検索結果の有無を確認（偽）
-          %h2.search__result__nil
-            お探しの商品はございません
         .items__box__content
+          
     -# = paginate@items
 = render "shared/footer"#フッターの呼び出し
 = render "shared/purchase"#出品ボタン（カメラアイコン）の呼び出し

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -101,12 +101,12 @@ ActiveRecord::Schema.define(version: 2020_03_05_082216) do
 
   create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "last_name_receiver", null: false
-    t.string "first_name_receiver", null: false
-    t.string "last_name_kana_receiver", null: false
-    t.string "first_name_kana_receiver", null: false
+    t.string "first_name_receive", null: false
+    t.string "last_name_kana_receive", null: false
+    t.string "first_name_kana_receive", null: false
     t.integer "zip_code_receiver", null: false
     t.text "address_receiver", null: false
-    t.string "tel_receiver"
+    t.string "tel_receive"
     t.bigint "prefecture_id", null: false
     t.bigint "payment_id", null: false
     t.bigint "item_id", null: false


### PR DESCRIPTION
# what
商品詳細検索強化

# why
検索時に空が検索結果０件と表示されていたので、「検索結果がありません」に変更
検索時にワイルドカードを入力しても全件出力されないように設定